### PR TITLE
feat(opds): add series navigation feed

### DIFF
--- a/Jellyfin.Plugin.Opds/OpdsApi.cs
+++ b/Jellyfin.Plugin.Opds/OpdsApi.cs
@@ -105,6 +105,27 @@ public class OpdsApi : ControllerBase
     }
 
     /// <summary>
+    /// Gets the list of book series.
+    /// </summary>
+    /// <returns>The series feed xml.</returns>
+    [HttpGet("Series")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult> GetSeries()
+    {
+        try
+        {
+            var userId = await AuthorizeAsync().ConfigureAwait(false);
+            var feeds = _opdsFeedProvider.GetBookSeries(Request.PathBase, userId);
+            return BuildOutput(feeds);
+        }
+        catch (AuthenticationException)
+        {
+            Response.Headers.Append(AuthHeaderKey, AuthHeaderValue);
+            return StatusCode(StatusCodes.Status401Unauthorized);
+        }
+    }
+
+    /// <summary>
     /// Gets the list of recently added books.
     /// </summary>
     /// <returns>The recently added feed xml.</returns>
@@ -181,6 +202,28 @@ public class OpdsApi : ControllerBase
         {
             var userId = await AuthorizeAsync().ConfigureAwait(false);
             var feeds = _opdsFeedProvider.GetBooksByGenre(Request.PathBase, userId, genreId);
+            return BuildOutput(feeds);
+        }
+        catch (AuthenticationException)
+        {
+            Response.Headers.Append(AuthHeaderKey, AuthHeaderValue);
+            return StatusCode(StatusCodes.Status401Unauthorized);
+        }
+    }
+
+    /// <summary>
+    /// Gets the list of books in the series.
+    /// </summary>
+    /// <param name="seriesId">The series id.</param>
+    /// <returns>The books feed xml.</returns>
+    [HttpGet("Series/{seriesId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult> GetBooksBySeries([FromRoute] Guid seriesId)
+    {
+        try
+        {
+            var userId = await AuthorizeAsync().ConfigureAwait(false);
+            var feeds = _opdsFeedProvider.GetBooksBySeries(Request.PathBase, userId, seriesId);
             return BuildOutput(feeds);
         }
         catch (AuthenticationException)

--- a/Jellyfin.Plugin.Opds/Services/IOpdsFeedProvider.cs
+++ b/Jellyfin.Plugin.Opds/Services/IOpdsFeedProvider.cs
@@ -32,6 +32,14 @@ public interface IOpdsFeedProvider
     FeedDto GetBookGenres(string baseUrl, Guid userId);
 
     /// <summary>
+    /// Gets the list of book series.
+    /// </summary>
+    /// <param name="baseUrl">The request path base.</param>
+    /// <param name="userId">The user id to filter by.</param>
+    /// <returns>The list of series.</returns>
+    FeedDto GetBookSeries(string baseUrl, Guid userId);
+
+    /// <summary>
     /// Gets the list of recently added books.
     /// </summary>
     /// <param name="baseUrl">The request path base.</param>
@@ -64,6 +72,15 @@ public interface IOpdsFeedProvider
     /// <param name="genreId">The genre id.</param>
     /// <returns>The books in the genre.</returns>
     FeedDto GetBooksByGenre(string baseUrl, Guid userId, Guid genreId);
+
+    /// <summary>
+    /// Gets the list of books within a series.
+    /// </summary>
+    /// <param name="baseUrl">The request path base.</param>
+    /// <param name="userId">The user id to filter by.</param>
+    /// <param name="seriesId">The series id.</param>
+    /// <returns>The books in the series.</returns>
+    FeedDto GetBooksBySeries(string baseUrl, Guid userId, Guid seriesId);
 
     /// <summary>
     /// Get the book image path.

--- a/Jellyfin.Plugin.Opds/Services/OpdsFeedProvider.cs
+++ b/Jellyfin.Plugin.Opds/Services/OpdsFeedProvider.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Mime;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
@@ -97,6 +100,17 @@ public class OpdsFeedProvider : IOpdsFeedProvider
                     Links = new List<LinkDto>
                     {
                         new(baseUrl + "/opds/genres", "application/atom+xml;profile=opds-catalog")
+                    }
+                },
+                new(
+                    "Series",
+                    "/opds/series",
+                    new ContentDto("text", "Book series"),
+                    timestamp)
+                {
+                    Links = new List<LinkDto>
+                    {
+                        new(baseUrl + "/opds/series", "application/atom+xml;profile=opds-catalog")
                     }
                 },
                 new(
@@ -230,6 +244,49 @@ public class OpdsFeedProvider : IOpdsFeedProvider
         }
 
         return feedDto;
+    }
+
+    /// <inheritdoc />
+    public FeedDto GetBookSeries(string baseUrl, Guid userId)
+    {
+        var utcNow = DateTime.UtcNow;
+        var entries = GetVisibleBooks(userId)
+            .Select(book => new
+            {
+                Book = book,
+                Name = GetSeriesName(book)
+            })
+            .Where(item => !string.IsNullOrWhiteSpace(item.Name))
+            .GroupBy(item => GetSeriesId(item.Book))
+            .Select(group => new
+            {
+                Id = group.Key,
+                Name = group.Select(item => item.Name).First()!
+            })
+            .OrderBy(series => series.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(series => new EntryDto(
+                series.Name,
+                "/opds/series/" + series.Id,
+                utcNow)
+            {
+                Links = new List<LinkDto>
+                {
+                    new(
+                        "subsection",
+                        baseUrl + "/opds/series/" + series.Id,
+                        "application/atom+xml;profile=opds-catalog")
+                }
+            })
+            .ToList();
+
+        return new FeedDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Author = PluginAuthor,
+            Title = GetFeedName("Series"),
+            Links = CreateNavigationLinks(baseUrl, "/opds/series"),
+            Entries = entries
+        };
     }
 
     /// <inheritdoc />
@@ -450,6 +507,29 @@ public class OpdsFeedProvider : IOpdsFeedProvider
     }
 
     /// <inheritdoc />
+    public FeedDto GetBooksBySeries(string baseUrl, Guid userId, Guid seriesId)
+    {
+        var books = GetVisibleBooks(userId)
+            .Where(book => GetSeriesId(book) == seriesId)
+            .OrderBy(book => book.SortName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var seriesName = books
+            .Select(GetSeriesName)
+            .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name))
+            ?? "Series";
+
+        return new FeedDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Author = PluginAuthor,
+            Title = GetFeedName(seriesName),
+            Links = CreateNavigationLinks(baseUrl, "/opds/series/" + seriesId),
+            Entries = books.Select(book => CreateEntry(book, baseUrl)).ToList()
+        };
+    }
+
+    /// <inheritdoc />
     public string? GetBookImage(Guid bookId)
     {
         var item = _libraryManager.GetItemById(bookId);
@@ -537,6 +617,62 @@ public class OpdsFeedProvider : IOpdsFeedProvider
     {
         var serverName = _serverApplicationHost.FriendlyName;
         return title + " - " + (string.IsNullOrEmpty(serverName) ? "Jellyfin" : serverName);
+    }
+
+    private IEnumerable<Book> GetVisibleBooks(Guid userId)
+    {
+        var query = new InternalItemsQuery
+        {
+            IncludeItemTypes = BookItemTypes,
+            OrderBy = new (ItemSortBy, SortOrder)[] { (ItemSortBy.SortName, SortOrder.Ascending) },
+            Recursive = true,
+            DtoOptions = new DtoOptions()
+        };
+
+        if (userId != Guid.Empty)
+        {
+            var user = _userManager.GetUserById(userId);
+            if (user is not null)
+            {
+                query.SetUser(user);
+            }
+        }
+
+        return _libraryManager.GetItemList(query).OfType<Book>();
+    }
+
+    private static string? GetSeriesName(Book book)
+    {
+        return book.GetLookupInfo().SeriesName;
+    }
+
+    private static Guid GetSeriesId(Book book)
+    {
+        if (book.SeriesId != Guid.Empty)
+        {
+            return book.SeriesId;
+        }
+
+        var seriesName = GetSeriesName(book);
+        if (string.IsNullOrWhiteSpace(seriesName))
+        {
+            return Guid.Empty;
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(seriesName.Trim().ToUpperInvariant()));
+        return new Guid(hash[..16]);
+    }
+
+    private static LinkDto[] CreateNavigationLinks(string baseUrl, string path)
+    {
+        return new[]
+        {
+            new LinkDto("self", baseUrl + path + "?", "application/atom+xml;profile=opds-catalog;type=feed;kind=navigation"),
+            new LinkDto("start", baseUrl + "/opds", "application/atom+xml;profile=opds-catalog;type=feed;kind=navigation"),
+            new LinkDto("up", baseUrl + "/opds", "application/atom+xml;profile=opds-catalog;type=feed;kind=navigation"),
+            new LinkDto("search", baseUrl + "/opds/osd", "application/opensearchdescription+xml"),
+            new LinkDto("search", baseUrl + "/opds/search/{searchTerms}", "application/atom+xml", "Search")
+        };
     }
 
     private EntryDto CreateEntry(Book book, string baseUrl)

--- a/Jellyfin.Plugin.Opds/Services/OpdsFeedProvider.cs
+++ b/Jellyfin.Plugin.Opds/Services/OpdsFeedProvider.cs
@@ -643,7 +643,7 @@ public class OpdsFeedProvider : IOpdsFeedProvider
 
     private static string? GetSeriesName(Book book)
     {
-        return book.GetLookupInfo().SeriesName;
+        return book.SeriesName;
     }
 
     private static Guid GetSeriesId(Book book)


### PR DESCRIPTION
## Summary
- add a Series navigation entry to the OPDS root feed
- expose authenticated series and per-series acquisition feeds
- use explicit Jellyfin SeriesName metadata and stable identifiers
- keep series results scoped to the authenticated user

## Testing
- dotnet build Jellyfin.Plugin.Opds.sln
- installed and exercised on a Jellyfin 12 instance

Refs #5